### PR TITLE
added OpenAICostTracker component

### DIFF
--- a/symai/backend/engine_embedding.py
+++ b/symai/backend/engine_embedding.py
@@ -5,19 +5,21 @@ from typing import List
 import openai
 
 from .base import Engine
+from .mixin.openai import OpenAIMixin
 from .settings import SYMAI_CONFIG
 
 
-class EmbeddingEngine(Engine):
+class EmbeddingEngine(Engine, OpenAIMixin):
     def __init__(self, max_retry: int = 3, api_cooldown_delay: int = 3):
         super().__init__()
-        config = SYMAI_CONFIG
-        openai.api_key = config['EMBEDDING_ENGINE_API_KEY']
-        self.model = config['EMBEDDING_ENGINE_MODEL']
         logger = logging.getLogger('openai')
         logger.setLevel(logging.WARNING)
-        self.max_retry = max_retry
+        config                  = SYMAI_CONFIG
+        openai.api_key          = config['EMBEDDING_ENGINE_API_KEY']
+        self.model              = config['EMBEDDING_ENGINE_MODEL']
+        self.max_retry          = max_retry
         self.api_cooldown_delay = api_cooldown_delay
+        self.pricing            = self.api_pricing()
 
     def command(self, wrp_params):
         super().command(wrp_params)

--- a/symai/backend/engine_gptX_chat.py
+++ b/symai/backend/engine_gptX_chat.py
@@ -6,10 +6,11 @@ import openai
 import tiktoken
 
 from .base import Engine
+from .mixin.openai import OpenAIMixin
 from .settings import SYMAI_CONFIG
 
 
-class GPTXChatEngine(Engine):
+class GPTXChatEngine(Engine, OpenAIMixin):
     def __init__(self, max_retry: int = 3, api_cooldown_delay: int = 3):
         super().__init__()
         logger = logging.getLogger('openai')
@@ -20,6 +21,7 @@ class GPTXChatEngine(Engine):
         self.max_retry          = max_retry
         self.api_cooldown_delay = api_cooldown_delay
         self.tokenizer          = tiktoken.encoding_for_model(self.model)
+        self.pricing            = self.api_pricing()
 
     def command(self, wrp_params):
         super().command(wrp_params)

--- a/symai/backend/mixin/openai.py
+++ b/symai/backend/mixin/openai.py
@@ -1,0 +1,24 @@
+import warnings
+
+
+class OpenAIMixin:
+    def api_pricing(self):
+        if self.model == 'gpt-3.5-turbo':
+            return {
+                'input':  0.0015 / 1_000,
+                'output': 0.0020 / 1_000
+            }
+
+        elif self.model == 'gpt-4':
+            return {
+                'input':  0.03 / 1_000,
+                'output': 0.06 / 1_000
+            }
+
+        elif self.model == 'text-embedding-ada-002':
+            return {
+                'usage': 0.0001 / 1_000
+            }
+
+        else:
+            warnings.warn(f'Engine not yet supported for cost calculation: {type(self)}')

--- a/symai/chat.py
+++ b/symai/chat.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from .backend import settings as settings
 from .components import (IncludeFilter, InContextClassification, Outline,
-                         Output, Sequence)
+                         Output, Sequence, OpenAICostTracker)
 from .core import *
 from .memory import Memory, SlidingWindowListMemory, VectorDatabaseMemory
 from .post_processors import ConsolePostProcessor, StripPostProcessor
@@ -284,10 +284,12 @@ The chatbot always reply in the following format
 
         return _func(self)
 
-
 def run() -> None:
-    chat = SymbiaChat()
-    chat()
+    with OpenAICostTracker() as tracker:
+        chat = SymbiaChat()
+        chat()
+    print(tracker)
 
 if __name__ == '__main__':
     run()
+

--- a/symai/functional.py
+++ b/symai/functional.py
@@ -3,6 +3,7 @@ import inspect
 import os
 import pickle
 import traceback
+import warnings
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
@@ -836,58 +837,99 @@ def bind_registry_func(
     ):
     if engine == 'neurosymbolic':
         check_or_init_neurosymbolic_func()
-        assert property in neurosymbolic_engine.__dict__, f'Property {property} not found in neurosymbolic engine'
-        return neurosymbolic_engine.__dict__[property]
+        if property not in neurosymbolic_engine.__dict__:
+            warnings.warn(f'Property {property} not found in neurosymbolic engine, returning None')
+
+        return neurosymbolic_engine.__dict__.get(property)
+
     if engine == 'symbolic':
         check_or_init_symbolic_func()
-        assert property in symbolic_engine.__dict__, f'Property {property} not found in symbolic engine'
-        return symbolic_engine.__dict__[property]
+        if property not in symbolic_engine.__dict__:
+            warnings.warn(f'Property {property} not found in symbolic engine, returning None')
+
+        return symbolic_engine.__dict__.get(property)
+
     if engine == 'ocr':
         check_or_init_ocr_func()
-        assert property in ocr_engine.__dict__, f'Property {property} not found in ocr engine'
-        return ocr_engine.__dict__[property]
+        if property not in ocr_engine.__dict__:
+            warnings.warn(f'Property {property} not found in ocr engine, returning None')
+
+        return ocr_engine.__dict__.get(property)
+
     if engine == 'vision':
         check_or_init_vision_func()
-        assert property in vision_engine.__dict__, f'Property {property} not found in vision engine'
-        return vision_engine.__dict__[property]
+        if property not in vision_engine.__dict__:
+            warnings.warn(f'Property {property} not found in vision engine, returning None')
+
+        return vision_engine.__dict__.get(property)
+
     if engine == 'speech':
         check_or_init_speech_func()
-        assert property in speech_engine.__dict__, f'Property {property} not found in speech engine'
-        return speech_engine.__dict__[property]
+        if property not in speech_engine.__dict__:
+            warnings.warn(f'Property {property} not found in speech engine, returning None')
+
+        return speech_engine.__dict__.get(property)
+
     if engine == 'embedding':
         check_or_init_embedding_func()
-        assert property in embedding_engine.__dict__, f'Property {property} not found in embedding engine'
-        return embedding_engine.__dict__[property]
+        if property not in embedding_engine.__dict__:
+            warnings.warn(f'Property {property} not found in embedding engine, returning None')
+
+        return embedding_engine.__dict__.get(property)
+
     if engine == 'userinput':
         check_or_init_userinput_func()
-        assert property in userinput_engine.__dict__, f'Property {property} not found in userinput engine'
-        return userinput_engine.__dict__[property]
+        if property not in userinput_engine.__dict__:
+            warnings.warn(f'Property {property} not found in userinput engine, returning None')
+
+        return userinput_engine.__dict__.get(property)
+
     if engine == 'search':
         check_or_init_search_func()
-        assert property in search_engine.__dict__, f'Property {property} not found in search engine'
-        return search_engine.__dict__[property]
+        if property not in search_engine.__dict__:
+            warnings.warn(f'Property {property} not found in search engine, returning None')
+
+        return search_engine.__dict__.get(property)
+
     if engine == 'crawler':
         check_or_init_crawler_func()
-        assert property in crawler_engine.__dict__, f'Property {property} not found in crawler engine'
-        return crawler_engine.__dict__[property]
+        if property not in crawler_engine.__dict__:
+            warnings.warn(f'Property {property} not found in crawler engine, returning None')
+
+        return crawler_engine.__dict__.get(property)
+
     if engine == 'execute':
         check_or_init_execute_func()
-        assert property in execute_engine.__dict__, f'Property {property} not found in execute engine'
-        return execute_engine.__dict__[property]
+        if property not in execute_engine.__dict__:
+            warnings.warn(f'Property {property} not found in execute engine, returning None')
+
+        return execute_engine.__dict__.get(property)
+
     if engine == 'index':
         check_or_init_index_func()
-        assert property in index_engine.__dict__, f'Property {property} not found in index engine'
-        return index_engine.__dict__[property]
+        if property not in index_engine.__dict__:
+            warnings.warn(f'Property {property} not found in index engine, returning None')
+
+        return index_engine.__dict__.get(property)
+
     if engine == 'open':
         check_or_init_open_func()
-        assert property in file_engine.__dict__, f'Property {property} not found in open engine'
-        return file_engine.__dict__[property]
+        if property not in file_engine.__dict__:
+            warnings.warn(f'Property {property} not found in open engine, returning None')
+
+        return file_engine.__dict__.get(property)
+
     if engine == 'output':
         check_or_init_output_func()
-        assert property in output_engine.__dict__, f'Property {property} not found in output engine'
-        return output_engine.__dict__[property]
+        if property not in output_engine.__dict__:
+            warnings.warn(f'Property {property} not found in output engine, returning None')
+
+        return output_engine.__dict__.get(property)
+
     if engine == 'imagerendering':
         check_or_init_imagerendering_func()
-        assert property in imagerendering_engine.__dict__, f'Property {property} not found in imagerendering engine'
-        return imagerendering_engine.__dict__[property]
+        if property not in imagerendering_engine.__dict__:
+            warnings.warn(f'Property {property} not found in imagerendering engine, returning None')
+
+        return imagerendering_engine.__dict__.get(property)
 


### PR DESCRIPTION
The `OpenAICostTracker` (#27) is supposed to offer cost transparency with our API. For example, now our Symbia chatbot (symchat) can be cost evaluated as well. I've opted for context managers, because they provide the most intuitive interface to the user. The usage is as simple as: 

```python
with OpenAICostTracker() as tracker: 
    # [execute code]
print(tracker)
```

The component tracks every use of `_execute_query`, which is our lowest level component. I've also tracked the how many times `zero_shot` and `few_shot` decorators were called.

Current support is only for: 
- gpt-3.5-turbo
- gpt-4
- text-embedding-ada-002 